### PR TITLE
Add multilingual React Native mobile app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,36 @@
-# actual-backend-app
-actual-backend-app
+# PerfumeApp Mobile Application
+
+This repository contains a simple React Native mobile application supporting **Arabic** and **French** languages. The UI follows a minimal dark theme and provides three main screens:
+
+- **Home** – welcome banner, brand slogan and featured product carousel.
+- **Market** – list of perfumes and accessories with filter and add-to-cart button.
+- **News** – latest articles or promotions.
+
+A language switcher in the top right corner toggles between Arabic (RTL) and French (LTR).
+
+## Structure
+
+```
+mobile-app/
+  package.json      # project dependencies
+  index.js          # entry point
+  App.js            # navigation and language initialization
+  src/
+    i18n/           # translations and i18n configuration
+      ar.json
+      fr.json
+      index.js
+    components/     # reusable UI pieces
+    screens/        # Home, Market and News implementations
+```
+
+## Running the app
+
+Install dependencies and start with Expo:
+
+```bash
+npm install
+yarn start
+```
+
+This requires a working React Native / Expo environment.

--- a/mobile-app/App.js
+++ b/mobile-app/App.js
@@ -1,0 +1,42 @@
+import React, { useState, useEffect } from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { View, ActivityIndicator } from 'react-native';
+
+import HomeScreen from './src/screens/HomeScreen';
+import MarketScreen from './src/screens/MarketScreen';
+import NewsScreen from './src/screens/NewsScreen';
+import { initLocalization } from './src/i18n';
+import LanguageSwitcher from './src/components/LanguageSwitcher';
+import i18n from './src/i18n';
+
+const Tab = createBottomTabNavigator();
+
+export default function App() {
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    // Initialize localization with device settings
+    initLocalization();
+    setLoading(false);
+  }, []);
+
+  if (loading) {
+    return (
+      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: '#000' }}>
+        <ActivityIndicator color="#fff" />
+      </View>
+    );
+  }
+
+  return (
+    <NavigationContainer>
+      <LanguageSwitcher />
+      <Tab.Navigator screenOptions={{ headerShown: false }}>
+        <Tab.Screen name="Home" component={HomeScreen} options={{ title: i18n.t('home') }} />
+        <Tab.Screen name="Market" component={MarketScreen} options={{ title: i18n.t('market') }} />
+        <Tab.Screen name="News" component={NewsScreen} options={{ title: i18n.t('news') }} />
+      </Tab.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/mobile-app/index.js
+++ b/mobile-app/index.js
@@ -1,0 +1,4 @@
+import { registerRootComponent } from 'expo';
+import App from './App';
+
+registerRootComponent(App);

--- a/mobile-app/package.json
+++ b/mobile-app/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "PerfumeApp",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "expo start"
+  },
+  "dependencies": {
+    "expo": "^48.0.0",
+    "react": "18.2.0",
+    "react-native": "0.71.8",
+    "i18n-js": "^4.2.0",
+    "expo-localization": "^14.0.0"
+  }
+}

--- a/mobile-app/src/components/LanguageSwitcher.js
+++ b/mobile-app/src/components/LanguageSwitcher.js
@@ -1,0 +1,34 @@
+import React, { useState } from 'react';
+import { View, TouchableOpacity, Text, StyleSheet } from 'react-native';
+import i18n, { initLocalization } from '../i18n';
+
+export default function LanguageSwitcher() {
+  const [lang, setLang] = useState(i18n.locale);
+
+  const toggleLang = () => {
+    const newLang = lang === 'ar' ? 'fr' : 'ar';
+    setLang(newLang);
+    initLocalization(newLang);
+  };
+
+  return (
+    <View style={styles.container}>
+      <TouchableOpacity onPress={toggleLang}>
+        <Text style={styles.text}>{lang === 'ar' ? 'FR' : 'AR'}</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    top: 40,
+    right: 20,
+    zIndex: 10
+  },
+  text: {
+    color: '#fff',
+    fontSize: 16
+  }
+});

--- a/mobile-app/src/components/ProductCard.js
+++ b/mobile-app/src/components/ProductCard.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import { View, Text, Image, StyleSheet, TouchableOpacity } from 'react-native';
+import i18n from '../i18n';
+
+export default function ProductCard({ product, onAdd }) {
+  return (
+    <View style={styles.card}>
+      <Image source={{ uri: product.image }} style={styles.image} />
+      <Text style={styles.name}>{product.name}</Text>
+      <Text style={styles.price}>{product.price} $</Text>
+      <TouchableOpacity onPress={() => onAdd(product)}>
+        <Text style={styles.add}>{i18n.t('add_to_cart')}</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: '#111',
+    padding: 10,
+    margin: 10,
+    borderRadius: 8,
+    width: 150,
+    alignItems: 'center'
+  },
+  image: {
+    width: 100,
+    height: 100,
+    marginBottom: 10
+  },
+  name: {
+    color: '#fff',
+    marginBottom: 5
+  },
+  price: {
+    color: '#fff',
+    marginBottom: 5
+  },
+  add: {
+    color: '#fff'
+  }
+});

--- a/mobile-app/src/i18n/ar.json
+++ b/mobile-app/src/i18n/ar.json
@@ -1,0 +1,14 @@
+{
+  "home": "الرئيسية",
+  "welcome": "مرحبا بك في تطبيقنا",
+  "slogan": "عطر الحياة",
+  "market": "السوق",
+  "news": "الأخبار",
+  "add_to_cart": "أضف إلى السلة",
+  "filter": "تصفية",
+  "featured_products": "منتجات مميزة",
+  "recent_news": "أحدث الأخبار",
+  "language": "اللغة",
+  "products": "منتجات",
+  "accessories": "اكسسوارات"
+}

--- a/mobile-app/src/i18n/fr.json
+++ b/mobile-app/src/i18n/fr.json
@@ -1,0 +1,14 @@
+{
+  "home": "Accueil",
+  "welcome": "Bienvenue dans notre application",
+  "slogan": "Parfumer la vie",
+  "market": "Boutique",
+  "news": "Actualités",
+  "add_to_cart": "Ajouter au panier",
+  "filter": "Filtrer",
+  "featured_products": "Produits phares",
+  "recent_news": "Dernières nouvelles",
+  "language": "Langue",
+  "products": "Parfums",
+  "accessories": "Accessoires"
+}

--- a/mobile-app/src/i18n/index.js
+++ b/mobile-app/src/i18n/index.js
@@ -1,0 +1,19 @@
+import i18n from 'i18n-js';
+import { I18nManager } from 'react-native';
+import * as Localization from 'expo-localization';
+
+import ar from './ar.json';
+import fr from './fr.json';
+
+// Configure translations
+i18n.fallbacks = true;
+i18n.translations = { ar, fr };
+
+// Initialize language based on device settings
+export const initLocalization = (locale) => {
+  const selectedLocale = locale || Localization.locale.split('-')[0];
+  i18n.locale = selectedLocale;
+  I18nManager.forceRTL(selectedLocale === 'ar');
+};
+
+export default i18n;

--- a/mobile-app/src/screens/HomeScreen.js
+++ b/mobile-app/src/screens/HomeScreen.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import { View, Text, StyleSheet, ScrollView, Image } from 'react-native';
+import i18n from '../i18n';
+
+const featured = [
+  { id: 1, image: 'https://placehold.co/300x200' },
+  { id: 2, image: 'https://placehold.co/300x200' },
+  { id: 3, image: 'https://placehold.co/300x200' }
+];
+
+export default function HomeScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.welcome}>{i18n.t('welcome')}</Text>
+      <Text style={styles.slogan}>{i18n.t('slogan')}</Text>
+      <ScrollView horizontal style={styles.carousel} showsHorizontalScrollIndicator={false}>
+        {featured.map(item => (
+          <Image key={item.id} source={{ uri: item.image }} style={styles.slide} />
+        ))}
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#000',
+    paddingTop: 80,
+    alignItems: 'center'
+  },
+  welcome: {
+    color: '#fff',
+    fontSize: 22,
+    marginBottom: 10
+  },
+  slogan: {
+    color: '#fff',
+    marginBottom: 20
+  },
+  carousel: {
+    flexGrow: 0
+  },
+  slide: {
+    width: 300,
+    height: 200,
+    marginRight: 10
+  }
+});

--- a/mobile-app/src/screens/MarketScreen.js
+++ b/mobile-app/src/screens/MarketScreen.js
@@ -1,0 +1,60 @@
+import React, { useState } from 'react';
+import { View, Text, StyleSheet, FlatList, TouchableOpacity } from 'react-native';
+import ProductCard from '../components/ProductCard';
+import i18n from '../i18n';
+
+const products = [
+  { id: 1, name: 'Perfume A', price: 50, image: 'https://placehold.co/100x100', category: 'products' },
+  { id: 2, name: 'Accessory B', price: 20, image: 'https://placehold.co/100x100', category: 'accessories' }
+];
+
+export default function MarketScreen() {
+  const [filter, setFilter] = useState(null);
+
+  const filtered = filter ? products.filter(p => p.category === filter) : products;
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.filterRow}>
+        <TouchableOpacity onPress={() => setFilter('products')} style={styles.filterButton}>
+          <Text style={styles.filterText}>{i18n.t('products')}</Text>
+        </TouchableOpacity>
+        <TouchableOpacity onPress={() => setFilter('accessories')} style={styles.filterButton}>
+          <Text style={styles.filterText}>{i18n.t('accessories')}</Text>
+        </TouchableOpacity>
+        <TouchableOpacity onPress={() => setFilter(null)} style={styles.filterButton}>
+          <Text style={styles.filterText}>{i18n.t('filter')}</Text>
+        </TouchableOpacity>
+      </View>
+      <FlatList
+        data={filtered}
+        numColumns={2}
+        keyExtractor={item => item.id.toString()}
+        renderItem={({ item }) => <ProductCard product={item} onAdd={() => {}} />}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#000',
+    paddingTop: 80
+  },
+  filterRow: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    marginBottom: 10
+  },
+  filterButton: {
+    marginHorizontal: 5,
+    borderColor: '#fff',
+    borderWidth: 1,
+    padding: 5,
+    borderRadius: 4
+  },
+  filterText: {
+    color: '#fff'
+  }
+});

--- a/mobile-app/src/screens/NewsScreen.js
+++ b/mobile-app/src/screens/NewsScreen.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import { View, Text, StyleSheet, FlatList, Image, TouchableOpacity } from 'react-native';
+import i18n from '../i18n';
+
+const news = [
+  { id: 1, title: 'New perfume launched', desc: 'Try our latest scent.', image: 'https://placehold.co/200x100' },
+  { id: 2, title: 'Summer sale', desc: 'Get 20% off.', image: 'https://placehold.co/200x100' }
+];
+
+export default function NewsScreen() {
+  const renderItem = ({ item }) => (
+    <TouchableOpacity style={styles.item}>
+      <Image source={{ uri: item.image }} style={styles.image} />
+      <View style={styles.info}>
+        <Text style={styles.title}>{item.title}</Text>
+        <Text style={styles.desc}>{item.desc}</Text>
+      </View>
+    </TouchableOpacity>
+  );
+
+  return (
+    <View style={styles.container}>
+      <FlatList data={news} keyExtractor={i => i.id.toString()} renderItem={renderItem} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#000',
+    paddingTop: 80
+  },
+  item: {
+    flexDirection: 'row',
+    margin: 10,
+    borderBottomColor: '#444',
+    borderBottomWidth: 1,
+    paddingBottom: 10
+  },
+  image: {
+    width: 100,
+    height: 50,
+    marginRight: 10
+  },
+  info: {
+    flex: 1
+  },
+  title: {
+    color: '#fff',
+    marginBottom: 5
+  },
+  desc: {
+    color: '#fff'
+  }
+});


### PR DESCRIPTION
## Summary
- create React Native project skeleton under `mobile-app`
- add i18n setup with Arabic and French translations
- implement language switcher component
- build Home, Market, and News screens using dark theme
- update README with usage instructions

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_688407e6e0a8832688f6096ab0704377